### PR TITLE
Initialize synfig version at every iteration 

### DIFF
--- a/generate-reference.sh
+++ b/generate-reference.sh
@@ -76,9 +76,9 @@ for file in $CHANGED_FILES; do
 			# just run for one dir
 			pushd $DIR
 			VERSION=`cat $NAME.txt`
-			get-synfig $VERSION
 			mkdir -p ${TRAVIS_BUILD_DIR}/$DIR/../../../references/${DIR#*/}
 			for sample in * ; do
+				get-synfig $VERSION
 				if [ -f "${TRAVIS_BUILD_DIR}/$DIR/$NAME.txt" ]; then
 					EXP_VERSION=`cat $NAME.txt`
 					get-synfig $EXP_VERSION


### PR DESCRIPTION
Sorry, I forget to add this here. It is already present at force render script :) Secondly, are we fine with whole rectangle getting re-rendered when rectangle-xyz.txt is changed?

Honestly I forgot to test  the basic testcase by adding rectange-xyz.txt. I tested it when default-version.txt is changed or rectangle.txt is changed. 